### PR TITLE
removed converter module from base import

### DIFF
--- a/pandapower/__init__.py
+++ b/pandapower/__init__.py
@@ -26,7 +26,6 @@ pd.options.mode.chained_assignment = None  # default='warn'
 
 # import pandapower packages
 import pandapower.control
-import pandapower.converter
 import pandapower.estimation
 import pandapower.grid_equivalents
 import pandapower.networks


### PR DESCRIPTION
Since the converter has its own set of dependencies it should not be imported every time a user uses `import pandapower` as this leads to issues.